### PR TITLE
Crash avoiding

### DIFF
--- a/src/android/PGMultiView.java
+++ b/src/android/PGMultiView.java
@@ -61,10 +61,16 @@ public class PGMultiView extends CordovaPlugin {
     //when we get the result of the child activity back, create a bundle that we unpack the "message to parent" from
     public void onActivityResult(int requestCode, int resultCode, Intent intent) {
         super.onActivityResult(requestCode, resultCode, intent);
-        Bundle bundle = intent.getExtras();
+        Bundle bundle = null ;
+        if(intent != null){
+            bundle = intent.getExtras();
+        }
         if (requestCode == RESULT_CODE) {
             if (resultCode == RESULT_OK) {
-                String messageFromChild = bundle.getString("Message to parent");
+                String messageFromChild = "";
+                if(bundle != null){
+                    messageFromChild = bundle.getString("Message to parent");
+                }
                 callbackContext.success(messageFromChild);
             }
         }


### PR DESCRIPTION
Under low memory situations(I assume) activities intent is being discarded. It been happening only when I have child activity in the background and I try to resume it by tapping on the app icon. I may be wrong but this should not harm only protect from null exceptions.